### PR TITLE
Eliminar Admin News, Agregar Mensajes de Exito con Toast

### DIFF
--- a/frontend/src/components/ui.disabled/Toast.tsx
+++ b/frontend/src/components/ui.disabled/Toast.tsx
@@ -1,0 +1,61 @@
+import { useEffect } from "react";
+import { CheckCircle, XCircle, X } from "lucide-react";
+
+interface ToastProps {
+  message: string;
+  type: "success" | "error";
+  onClose: () => void;
+  duration?: number;
+}
+
+export function Toast({ message, type, onClose, duration = 4000 }: ToastProps) {
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      onClose();
+    }, duration);
+
+    return () => clearTimeout(timer);
+  }, [duration, onClose]);
+
+  return (
+    <div className="fixed top-4 right-4 z-[100] animate-slide-in">
+      <div
+        className={`min-w-[320px] max-w-md rounded-lg shadow-2xl border-2 p-4 flex items-start gap-3 ${
+          type === "success"
+            ? "bg-card border-vcf-orange"
+            : "bg-card border-red-500"
+        }`}
+      >
+        <div className="flex-shrink-0">
+          {type === "success" ? (
+            <div className="w-10 h-10 bg-vcf-orange rounded-full flex items-center justify-center">
+              <CheckCircle size={24} className="text-white" />
+            </div>
+          ) : (
+            <div className="w-10 h-10 bg-red-500 rounded-full flex items-center justify-center">
+              <XCircle size={24} className="text-white" />
+            </div>
+          )}
+        </div>
+
+        <div className="flex-1 pt-1">
+          <h3
+            className={`font-black text-base mb-1 ${
+              type === "success" ? "text-vcf-orange" : "text-red-500"
+            }`}
+          >
+            {type === "success" ? "¡ÉXITO!" : "¡ERROR!"}
+          </h3>
+          <p className="text-sm text-foreground font-bold">{message}</p>
+        </div>
+
+        <button
+          onClick={onClose}
+          className="flex-shrink-0 text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <X size={20} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/AdminViews/ManageCards.tsx
+++ b/frontend/src/pages/AdminViews/ManageCards.tsx
@@ -12,6 +12,7 @@ import {
   Gem,
   Award,
 } from "lucide-react";
+import { Toast } from "@/components/ui.disabled/Toast";
 
 export function ManageCards(){
 
@@ -20,6 +21,10 @@ export function ManageCards(){
     const [loading, setLoading] = useState(true);
     const [filterCategory, setFilterCategory] = useState<string>("Todas");
     const [searchTerm, setSearchTerm] = useState("");
+    const [toast, setToast] = useState<{
+        message: string;
+        type: "success" | "error";
+    } | null>(null);
 
 
     console.log(loading)
@@ -102,6 +107,23 @@ export function ManageCards(){
     const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault(); 
 
+    // Validación
+    if (!formData.nombre.trim()) {
+      setToast({
+        message: "El nombre de la carta es obligatorio",
+        type: "error",
+      });
+      return;
+    }
+
+    if (!formData.numero || parseInt(formData.numero) <= 0) {
+      setToast({
+        message: "El valor de la carta debe ser mayor a 0",
+        type: "error",
+      });
+      return;
+    }
+
     try {
         await addCard(
         formData.nombre,
@@ -123,11 +145,17 @@ export function ManageCards(){
         numero: 0,
         });
         setFile(null);
+        setShowForm(false);
 
-        alert("Carta agregada correctamente");
+        setToast({
+        message: `Carta "${formData.nombre}" creada exitosamente`,
+        type: "success",
+        });
     } catch (error) {
-        console.error(error);
-        alert("Error al guardar la carta");
+        setToast({
+        message: `Error al guardar la carta`,
+        type: "error",
+        });
     }
     };
 
@@ -458,6 +486,14 @@ export function ManageCards(){
                     </form>
                 </div>
                 </div>
+            )}
+            {/* Toast Notifications */}
+            {toast && (
+                <Toast
+                message={toast.message}
+                type={toast.type}
+                onClose={() => setToast(null)}
+                />
             )}
         </div>
     );


### PR DESCRIPTION
Se elimino en Administrador el manejo de las Noticias, debido a que ahora se usara un proveedor de Noticias de igual manera de borro la tabla de News dentro de la Base de Datos y el Servicio de la misma. Se agrego componente de UI "Toast" para los mensajes de exito y error, se modifico en Manage Cards para dejar de usar alerts a usar el Toast.